### PR TITLE
Fixes API >= 31

### DIFF
--- a/library/src/main/java/dev/bmcreations/scrcast/internal/recorder/notification/RecorderNotificationProvider.kt
+++ b/library/src/main/java/dev/bmcreations/scrcast/internal/recorder/notification/RecorderNotificationProvider.kt
@@ -138,7 +138,7 @@ class RecorderNotificationProvider(
 
                 val actionPendingIntent: PendingIntent =
                     PendingIntent.getBroadcast(
-                        context, requestId, actionIntent, PendingIntent.FLAG_ONE_SHOT
+                        context, requestId, actionIntent, PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
                     )
 
                 addAction(
@@ -162,7 +162,7 @@ class RecorderNotificationProvider(
             }
             val stopPendingIntent: PendingIntent =
                 PendingIntent.getBroadcast(
-                    context, requestId, stopIntent, PendingIntent.FLAG_ONE_SHOT
+                    context, requestId, stopIntent, PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
                 )
 
             addAction(


### PR DESCRIPTION
Starting in API 31 the intent must have `PendingIntent.FLAG_IMMUTABLE` or `PendingIntent.FLAG_MUTABLE` set. Since `FLAG_MUTABLE` does not exist until API 31, we must use `FLAG_IMMUTABLE` for compatibility or else change the compile target to >= 31.

The app demo included in this repo has been tested to work correctly with no crashes or errors.